### PR TITLE
Use total_seconds to avoid issues when fcint is over 24 hours in create_forcing

### DIFF
--- a/surfex/variable.py
+++ b/surfex/variable.py
@@ -417,7 +417,7 @@ class Variable(object):
                  second=0, microsecond=0)).total_seconds())
         if seconds_since_midnight == 86400:
             seconds_since_midnight = 0
-        basetime_inc = int(seconds_since_midnight / int(timedelta(seconds=self.fcint).seconds))
+        basetime_inc = int(seconds_since_midnight / int(timedelta(seconds=self.fcint).total_seconds()))
 
         prefer_forecast = timedelta(seconds=0)
         if seconds_since_midnight == basetime_inc * int(timedelta(seconds=self.fcint).seconds):


### PR DESCRIPTION
Originally `fcint` is converted to a `datetime.timedelta` object, but then to convert it to the `fcint` value to seconds a corresponding member of the object is accessed. But when using `datetime.timedelta.seconds` the returned value is always less than 1 day. Thus, to get a correct conversion to seconds for long `fcints` the `datetime.timedelta.total_seconds` function should be used.