### PR TITLE
Fixes for generating forcing from rotated_ll GRIB input

### DIFF
--- a/surfex/grib.py
+++ b/surfex/grib.py
@@ -147,14 +147,14 @@ class Grib(object):
 
                         lons = np.array(lons)
                         lats = np.array(lats)
-                        longitudes, latitudes = np.meshgrid(lons, lats)
+                        longitudes, latitudes = np.meshgrid(lons, lats, indexing='ij')
                         lons, lats = \
                             pyproj.Transformer.from_crs(proj, wgs84, always_xy=True).transform(longitudes, latitudes)
                         lons = lons + sp_lon
 
                         field = np.reshape(values, [n_x, n_y], order="F")
                         if geo_out is None:
-                            geo_out = surfex.geo.Geo(n_x * n_y, n_x, n_y, lons, lats)
+                            geo_out = surfex.geo.Geo(lons, lats)
 
                     elif grid_type.lower() == "regular_ll":
                         geo_keys = [


### PR DESCRIPTION
This PR changes indexing order of the computed longitudes and latitudes arrays to avoid array dimension mismatch errors, and corrects the arguments passed to the Geo object constructor. This allows generating SURFEX forcing from `rotated_ll` GRIB input with nearest neighbor interpolation.