### PR TITLE
Make the '-o' command line argument optional for SURFEX binary tasks

### DIFF
--- a/pysurfex/cli.py
+++ b/pysurfex/cli.py
@@ -582,7 +582,7 @@ def run_surfex_binary(mode, **kwargs):
         else:
             raise FileNotFoundError("File not found: " + archive)
 
-    if not os.path.exists(output) or force:
+    if not (output is not None and os.path.exists(output)) or force:
         if os.path.isfile(namelist_path):
             with open(namelist_path, mode="r", encoding="utf-8") as file_handler:
                 nam_defs = yaml.safe_load(file_handler)

--- a/pysurfex/cmd_parsing.py
+++ b/pysurfex/cmd_parsing.py
@@ -947,7 +947,7 @@ def parse_args_surfex_binary(argv, mode):
     parser.add_argument(
         "--domain", type=str, required=False, help="JSON file with domain"
     )
-    parser.add_argument("--output", "-o", type=str, required=True)
+    parser.add_argument("--output", "-o", type=str, required=False, default=None)
     parser.add_argument("--dtg", type=str, required=False, default=None)
     parser.add_argument("--basetime", type=str, required=False, default=None)
     if pert:


### PR DESCRIPTION
This PR updates the processing of command line arguments for SURFEX binary tasks allowing users to not store SURFEX output, if desired.