### PR TITLE
Use the latest dev gridpp version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@
 
 #[tool.poetry.group.points.dependencies]
     requests = "^2.28.2"
-    gridpp = "^0.6.0"
+    gridpp = "0.7.0.dev7"
     titanlib = "^0.3.3"
 
 #[tool.poetry.group.plot.dependencies]


### PR DESCRIPTION
This PR updates the project dependencies to use the latest available version of the `gridpp` package. It would have to be updated again when `gridpp` version `0.7.0` is released, but for now the latest development version is used to allow proper testing of sea ice and snow OI with `pysurfex`.