### PR TITLE
Update configuration.py

### DIFF
--- a/pysurfex/configuration.py
+++ b/pysurfex/configuration.py
@@ -550,7 +550,7 @@ class ConfigurationFromHarmonie(Configuration):
             gsize = float(env["LGSIZE"])
         trunc = 2  # linear
         if "TRUNC" in env:
-            trunc = int(env["TRUNC"])
+            trunc = int(float(env["TRUNC"]))
         domain_dict = {
             "nam_pgd_grid": {"cgrid": "CONF PROJ"},
             "nam_conf_proj": {

--- a/pysurfex/configuration.py
+++ b/pysurfex/configuration.py
@@ -550,7 +550,7 @@ class ConfigurationFromHarmonie(Configuration):
             gsize = float(env["LGSIZE"])
         trunc = 2  # linear
         if "TRUNC" in env:
-            trunc = int(float(env["TRUNC"]))
+            trunc = float(env["TRUNC"])
         domain_dict = {
             "nam_pgd_grid": {"cgrid": "CONF PROJ"},
             "nam_conf_proj": {


### PR DESCRIPTION
Avoid crash in case non-integer TRUNC values are used, e.g. when trunc is set to custom. TRUNC will still be handled as an integer in pysurfex.